### PR TITLE
Revert "Link to Chagelog advice"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,3 @@ Various files to support upcoming GitHub tasks the series trains you for, but mo
 ## License
 
 This repository is © 2015 Christophe Porteneuve, provided under the [MIT license](LICENSE), and part of a video training series produced for and distributed by O’Reilly.
-
-[Link to Changelog](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages)


### PR DESCRIPTION
Reverts git-ajkc-org/oreilly-github-demo#1